### PR TITLE
feat: 에너지 구매시 10개씩 구매하도록 변경

### DIFF
--- a/src/app/learn/components/LevelProgress.tsx
+++ b/src/app/learn/components/LevelProgress.tsx
@@ -10,7 +10,7 @@ import { LEVEL_CATEGORIES, levelInfo } from '@/lib/game/levels'
 export default function LevelProgress() {
   const router = useRouter()
   const { profile } = useAuth()
-  const { energy, maxEnergy, remainingSeconds } = useEnergy()
+  const { energy, remainingSeconds } = useEnergy()
   const [showModal, setShowModal] = useState(false)
   const [levelProgress, setLevelProgress] = useState({ completed: 0, total: 0 })
   const [isExpanded, setIsExpanded] = useState(false)
@@ -134,7 +134,7 @@ export default function LevelProgress() {
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2 text-sm">
           <span className="font-medium">에너지: {energy}</span>
-          {energy < maxEnergy && typeof remainingSeconds === 'number' && remainingSeconds > 0 && (
+          {energy < 5 && typeof remainingSeconds === 'number' && remainingSeconds > 0 && (
             <span className="text-xs text-neutral-500">({formatTime(remainingSeconds)})</span>
           )}
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,8 +5,7 @@ import Link from 'next/link'
 import { useEnergy } from '@/lib/store/energyStore'
 export default function Header() {
   const { user, profile } = useAuth()
-  const { energy, maxEnergy } = useEnergy()
-  const { remainingSeconds } = useEnergy()
+  const { energy, remainingSeconds } = useEnergy()
 
   if (!user || !profile) return null
 
@@ -23,7 +22,7 @@ export default function Header() {
             <path fillRule="evenodd" d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z" clipRule="evenodd" />
           </svg>
           <span className="text-sm font-semibold">{energy}</span>
-          {energy < maxEnergy && remainingSeconds && (
+          {energy < 5 && remainingSeconds && (
             <div className="flex items-center gap-1 text-xs text-neutral-500">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />

--- a/src/components/modals/EnergyModal.tsx
+++ b/src/components/modals/EnergyModal.tsx
@@ -10,12 +10,15 @@ export default function EnergyModal({ open, onClose }: { open: boolean; onClose:
   if (!open) return null
 
   async function handleBuy() {
-    // price: 100G per energy
-    const price = 100
+    // 10개 구매: 1000G
+    const energyAmount = 10
+    const pricePerEnergy = 100
+    const totalPrice = energyAmount * pricePerEnergy
+
     if (!spendGold) return
-    const ok = await spendGold(price)
+    const ok = await spendGold(totalPrice)
     if (ok) {
-      add(1)
+      add(energyAmount)
       onClose()
     } else {
       alert('골드가 부족합니다.')
@@ -26,10 +29,16 @@ export default function EnergyModal({ open, onClose }: { open: boolean; onClose:
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
       <div className="bg-white p-6 rounded-md w-80">
         <h3 className="font-medium mb-2">에너지 충전</h3>
-        <div className="text-sm text-neutral-600 mb-4">골드로 에너지를 구매할 수 있습니다. 1에너지 = 100G</div>
+        <div className="text-sm text-neutral-600 mb-4">
+          골드로 에너지를 구매할 수 있습니다.
+          <div className="mt-2 p-3 bg-primary-50 border border-primary-200 rounded-md">
+            <p className="font-semibold text-primary-700">10 에너지 = 1,000G</p>
+            <p className="text-xs text-primary-600 mt-1">한 번에 10개씩 구매됩니다</p>
+          </div>
+        </div>
         <div className="flex justify-end gap-2">
           <button className="btn-secondary" onClick={onClose}>취소</button>
-          <button className="btn-primary" onClick={handleBuy}>구매하기</button>
+          <button className="btn-primary" onClick={handleBuy}>1,000G로 구매</button>
         </div>
       </div>
     </div>

--- a/src/lib/store/energyStore.tsx
+++ b/src/lib/store/energyStore.tsx
@@ -4,11 +4,10 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 import React, { createContext, useContext, useEffect } from 'react'
 
 const ENERGY_RECOVERY_SECONDS = 60 // 1분으로 수정 (기존: 4 * 60 * 60)
-const MAX_ENERGY = 5
+const AUTO_RECOVERY_THRESHOLD = 5 // 5개 이하일 때만 자동 충전
 
 interface EnergyState {
   energy: number
-  maxEnergy: number
   lastUpdated: number
   remainingSeconds: number | null
   consume: (amount?: number) => boolean
@@ -19,8 +18,7 @@ interface EnergyState {
 const useEnergyStore = create<EnergyState>()(
   persist(
     (set, get) => ({
-      energy: MAX_ENERGY,
-      maxEnergy: MAX_ENERGY,
+      energy: AUTO_RECOVERY_THRESHOLD,
       lastUpdated: Date.now(),
       remainingSeconds: null,
 
@@ -28,7 +26,7 @@ const useEnergyStore = create<EnergyState>()(
         if (get().energy >= amount) {
           set(state => ({
             energy: state.energy - amount,
-            lastUpdated: state.energy === MAX_ENERGY ? Date.now() : state.lastUpdated,
+            lastUpdated: state.energy > AUTO_RECOVERY_THRESHOLD ? state.lastUpdated : Date.now(),
           }))
           return true
         }
@@ -37,13 +35,14 @@ const useEnergyStore = create<EnergyState>()(
 
       add: (amount: number) => {
         set(state => ({
-          energy: Math.min(MAX_ENERGY, state.energy + amount),
+          energy: state.energy + amount, // 최대 제한 제거
         }))
       },
 
       _updateEnergy: () => {
         set(state => {
-          if (state.energy >= MAX_ENERGY) {
+          // 5개 이하일 때만 자동 충전
+          if (state.energy >= AUTO_RECOVERY_THRESHOLD) {
             return { remainingSeconds: null }
           }
 
@@ -52,7 +51,7 @@ const useEnergyStore = create<EnergyState>()(
           const recoveredEnergy = Math.floor(elapsed / ENERGY_RECOVERY_SECONDS)
 
           if (recoveredEnergy > 0) {
-            const newEnergy = Math.min(MAX_ENERGY, state.energy + recoveredEnergy)
+            const newEnergy = Math.min(AUTO_RECOVERY_THRESHOLD, state.energy + recoveredEnergy)
             const newLastUpdated = state.lastUpdated + recoveredEnergy * ENERGY_RECOVERY_SECONDS * 1000
             return { energy: newEnergy, lastUpdated: newLastUpdated }
           }


### PR DESCRIPTION
자동 충전:
에너지가 5개 이하일 때만 자동 충전
1분마다 1개씩 자동 충전 (최대 5개)
5개 초과 시 타이머 중지
구매:
한 번에 10개 구매
가격: 1,000G
최대 개수 제한 없음
표시:
헤더와 학습 페이지에서 에너지 개수 표시
5개 이하일 때만 충전 타이머 표시